### PR TITLE
[PRINTER] adding basic asm printing support

### DIFF
--- a/src/codegen/asm.rs
+++ b/src/codegen/asm.rs
@@ -3,8 +3,8 @@ use crate::codegen::Allocation;
 /// Structure to store an assembly instruction
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AssemblyInst {
-    ops: Vec<Allocation>,
-    opcode: String,
+    pub(crate) ops: Vec<Allocation>,
+    pub(crate) opcode: String,
 }
 
 impl AssemblyInst {

--- a/src/codegen/inst_selec.rs
+++ b/src/codegen/inst_selec.rs
@@ -3,19 +3,16 @@ use crate::codegen::{AllocatedIrNode, ArchBackend, AssemblyInst};
 /// Stores the assembly for a function
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FuncAsm {
-    insts: Vec<AssemblyInst>,
+    pub(crate) insts: Vec<AssemblyInst>,
+    pub(crate) name: String,
 }
-
-impl Default for FuncAsm {
-    fn default() -> Self {
-        FuncAsm::new()
-    }
-}
-
 impl FuncAsm {
     /// Creates a new instance
-    pub fn new() -> Self {
-        Self { insts: Vec::new() }
+    pub fn new(name: String) -> Self {
+        Self {
+            insts: Vec::new(),
+            name,
+        }
     }
 
     pub(crate) fn add(&mut self, inst: AssemblyInst) {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -16,3 +16,31 @@ pub use dropper::*;
 pub use inst_selec::*;
 pub use regalloc::*;
 pub use target::*;
+
+/// The result of an compilation
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Compilation {
+    /// The compilation result of the functions
+    pub funcs: Vec<FuncAsm>,
+    /// The target architecture
+    pub arch: TargetArch,
+}
+
+impl Compilation {
+    /// Creates a new empty compilation result
+    pub fn new(arch: TargetArch) -> Self {
+        Self {
+            funcs: Vec::new(),
+            arch,
+        }
+    }
+    /// Adds the compilation result from a function
+    pub fn add(&mut self, asm: FuncAsm) {
+        self.funcs.push(asm);
+    }
+
+    /// Returns a fully formated assembly code ready to be printed
+    pub fn asm(&self) -> String {
+        self.arch.backend().print_compilation(self)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,5 +23,7 @@ fn main() {
 
     module.add_func(func);
 
-    module.compile(codegen::TargetArch::X86);
+    let asm = module.compile(codegen::TargetArch::X86);
+
+    println!("{}", asm.asm());
 }

--- a/src/x86/asmprinter.rs
+++ b/src/x86/asmprinter.rs
@@ -1,0 +1,68 @@
+use crate::{
+    codegen::{AsmPrinter, AssemblyInst},
+    x86::X86Backend,
+};
+
+macro_rules! reg_printer {
+    ($num_var:tt, $ty_var:tt, $num_lit:literal, $b64_name:expr) => {
+        if *$num_var == $num_lit {
+            match $ty_var {
+                crate::ir::TypeMetadata::Int64 => return $b64_name.to_string(),
+                other => todo!("Implement handling for type: {:?}", other),
+            }
+        }
+    };
+}
+
+impl AsmPrinter for X86Backend {
+    fn print_op(&self, op: &crate::codegen::Allocation) -> String {
+        match op {
+            crate::codegen::Allocation::Register { id, ty } => self.print_reg(id, ty),
+            crate::codegen::Allocation::Stack { slot, ty: _ } => format!("[rsp + {}]", slot * 16),
+        }
+    }
+
+    #[allow(unreachable_patterns)]
+    fn print_reg(&self, num: &usize, ty: &crate::ir::TypeMetadata) -> String {
+        reg_printer!(num, ty, 0, "rax");
+        reg_printer!(num, ty, 1, "rcx");
+        reg_printer!(num, ty, 2, "rdx");
+        reg_printer!(num, ty, 3, "rbx");
+        reg_printer!(num, ty, 4, "rsp");
+        reg_printer!(num, ty, 5, "rbp");
+        reg_printer!(num, ty, 6, "rsi");
+        reg_printer!(num, ty, 7, "rdi");
+        reg_printer!(num, ty, 8, "r8");
+        reg_printer!(num, ty, 9, "r9");
+        reg_printer!(num, ty, 10, "r10");
+        reg_printer!(num, ty, 11, "r11");
+        reg_printer!(num, ty, 12, "r12");
+        reg_printer!(num, ty, 13, "r13");
+        reg_printer!(num, ty, 14, "r14");
+        reg_printer!(num, ty, 15, "r15");
+        panic!("Impossible register id: {num}. X86 supports 0-15");
+    }
+
+    fn print_inst(&self, inst: &AssemblyInst) -> String {
+        if inst.opcode == "lea" {
+            return format!(
+                "\tlea {}, [{} + {}]\n",
+                self.print_op(&inst.ops[0]),
+                self.print_op(&inst.ops[1]),
+                self.print_op(&inst.ops[2])
+            );
+        }
+
+        let mut ops = String::new();
+
+        for (index, op) in inst.ops.iter().enumerate() {
+            if index != 0 {
+                ops += ", ";
+            }
+
+            ops += &self.print_op(op);
+        }
+
+        format!("\t{} {}\n", inst.opcode, ops)
+    }
+}

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -3,13 +3,15 @@
 use procmacro::patterns;
 
 use crate::{
-    codegen::{Allocation, ArchBackend, AssemblyInst, BackendInst, Reg},
+    codegen::{Allocation, ArchBackend, BackendInst, Reg},
     ir::TypeMetadata,
     x86::regs::*,
 };
 
 /// The registers to use in x86
 pub mod regs;
+
+mod asmprinter;
 
 /// This structure defines the entire x86 backend
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -69,6 +71,10 @@ impl BackendInst for X86Backend {
         Add(Gr, Gr) -> Gr {
             condition: in1 == out
             asm: add (in1, in2)
+        }
+        Add(Gr, Gr) -> Gr {
+            condition: in2 == out
+            asm: add (in2, in1)
         }
         Add(Gr, Gr) -> Gr {
             condition: in1 != out && in2 != out


### PR DESCRIPTION
Completes task:
> Starting basic assembly printer trait with default implementations for as easy as possible implementation when adding a new architecture
from #1 
This Pr adds:
 - A simple assembly printing trait with support for printing a `Compilation`
 - Implementation of the asmprinter for the x86 backend